### PR TITLE
Add optional alternate caching. Improved docs. Small tweaks and fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.gem
 .DS_Store
+vendor/
+Gemfile.lock
+.bundle

--- a/README.md
+++ b/README.md
@@ -2,19 +2,75 @@
 
 jive-ruby
 =========
-
 A Ruby Interface to the Jive REST API (https://developers.jivesoftware.com/api/rest).
 
 Apologies, but the documentation is low down on my list of priorities for the project I am working on at the moment. This code is messy and could do with some refactoring. There are bugs and it's a work in progress.
 
-To get going:
-
+Simple Example:
+```ruby
     require 'jive_api'
     j = Jive::Api '<username>', '<password>', '<uri of your jive server>'
     me = j.person_by_username '<username>'
     puts me.display_name
+```
+## Usage
+-------
+`Jive::API` instances have methods that can query Jive for various types of objects. `Jive::API` handles the work of pagination and marshaling the responses into Ruby objects.
+### Examples:
+#### Spaces
+```ruby
+spaces = j.spaces
+spaces.class
+=> Array
+spaces.first.class
+=> Jive::Space
+space = spaces.first
+space.name
+=> "My Cool Space"
+space.id
+=> 1023
+```
+#### Space Contents
+```ruby
+contents = space.contents
+contents.class
+=> Array
+doc = contents.first
+doc.class
+=> Jive::Document
+doc.content_methods
+=> [:get,
+ :attachments,
+ :has_attachments?,
+ :author,
+ :visibility,
+ :updated_at,
+ :content_id,
+ :comments,
+ :raw_data,
+ :uri,
+ :type,
+ :parent,
+ :id,
+ :self_uri,
+ :subject,
+ :display_name,
+ :html_uri,
+ :display_path]
+ doc.get
+ => "<body>..."
+ doc.type
+ => "document"
+ doc.subject
+ => "Some cool document"
+```
+#### Caching
+`Jive::API` instances can be created with different caching mechanisms. By default `Jive::API` will attempt to use Memcached running on `localhost:11211`. However, if you don't want to use Memcached you can create an instance using in-memory hashing:
+```ruby
+j = Jive::Api.new("user","password","url", Jive::Cache::Hashcache)
+```
 
-Example
+Examples
 -------
 
 There is some code in the /examples directory. 

--- a/jive_api.gemspec
+++ b/jive_api.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "Jive API Connector for Ruby"
   s.authors     = ["Andrew Beresford"]
   s.email       = "beezly@beezly.org.uk"
-  s.files       = ["lib/jive_api.rb"]
+  s.files       = ["lib/jive_api.rb", "lib/cache.rb"]
   s.homepage    = "http://github.com/beezly/jive-ruby"
   s.add_dependency 'httparty', '>= 0.10.0'
   s.add_dependency 'hashery', '>= 2.1.0'

--- a/jive_api.gemspec
+++ b/jive_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'jive_api'
-  s.version     = '0.0.4.pre'
+  s.version     = '0.0.5.pre'
   s.date        = '2014-02-28'
   s.summary     = "Jive API"
   s.description = "Jive API Connector for Ruby"

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -1,0 +1,45 @@
+require 'dalli'
+
+module Jive
+    module Cache
+        class Memcache
+            def initialize(host, opts={})
+                @client = Dalli::Client.new(host, opts)
+            end
+
+            def set(k,v)
+                @client.set(k,v)
+            end
+
+            def get(k)
+                @client.get(k)
+            end
+            
+            def has_key?(k)
+                 @client.has_key?(k)
+            end
+        end
+
+        class Hashcache
+            def initialize(*)
+                @cache_hash = {}
+            end
+
+            def set(k,v)
+                @cache_hash[k] = v
+            end
+
+            def get(k)
+                @cache_hash[k]
+            end
+
+            def has_key?(k)
+                @cache_hash.has_key? k
+            end
+        end
+        PROVIDERS = {
+            memcache: Memcache,
+            hashcache: Hashcache
+        }
+    end
+end

--- a/lib/jive_api.rb
+++ b/lib/jive_api.rb
@@ -4,8 +4,7 @@ require 'net/http'
 require 'uri'
 require 'date'
 require 'hashery/lru_hash'
-require 'dalli'
-
+require 'cache'
 module Jive
   module GettableBinaryURL
     def get_binary
@@ -313,12 +312,11 @@ module Jive
       end
     end
 
-    def initialize username, password, uri
-      @urllist_cache = Dalli::Client.new('localhost:11211', :namespace => "urllist_cache", :compress => true)
-      @objectdata_cache = Dalli::Client.new('localhost:11211', :namespace => "objectdata_cache", :compress => true)
-      @contentlist_cache = Dalli::Client.new('localhost:11211', :namespace => "contentlist_cache", :compress => true)
-      @container_cache = Dalli::Client.new('localhost:11211', :namespace => "container_cache", :compress => true, :value_max_bytes => 1024*1024*16)
-      #@object_cache = Hashery::LRUHash.new 1000000
+    def initialize username, password, uri, cache_type=Cache::Memcache
+      @urllist_cache     = cache_type.new('localhost:11211', :namespace => "urllist_cache", :compress => true)
+      @objectdata_cache  = cache_type.new('localhost:11211', :namespace => "objectdata_cache", :compress => true)
+      @contentlist_cache = cache_type.new('localhost:11211', :namespace => "contentlist_cache", :compress => true)
+      @container_cache   = cache_type.new('localhost:11211', :namespace => "container_cache", :compress => true, :value_max_bytes => 1024*1024*16)
       @uri_cache = Hashery::LRUHash.new 1000000
       @auth = { :username => username, :password => password }
       self.class.base_uri uri
@@ -345,7 +343,7 @@ module Jive
           parsed_response=@uri_cache[next_uri+options.to_s]
         else 
           response=self.class.get(next_uri, options.merge({:basic_auth => @auth}))
-          raise Error if response.parsed_response.has_key? 'error'
+          raise Error unless response.response.code == "200"
           parsed_response=response.parsed_response
           @uri_cache[next_uri+options.to_s]=parsed_response
         end

--- a/lib/jive_api.rb
+++ b/lib/jive_api.rb
@@ -89,6 +89,10 @@ module Jive
       @content
     end
 
+    def content_methods
+      self.methods - Object.methods
+    end
+
   end
 
   class Document < Content
@@ -189,6 +193,10 @@ module Jive
 
   class Idea < Content
   end
+
+  class Video < Content
+  end
+
 
   class Person < Container
     attr_reader :display_name, :userid, :status

--- a/test/test_jive_api.rb
+++ b/test/test_jive_api.rb
@@ -7,7 +7,7 @@ class TestJiveAPI < Test::Unit::TestCase
     @url = ENV['JIVE_URL']
     @user = ENV['JIVE_USER']
     @pass = ENV['JIVE_PASS']
-    @api = Jive::Api.new @user, @pass, @url
+    @api = Jive::Api.new @user, @pass, @url, Jive::Cache::Hashcache
   end
 
   def test_version


### PR DESCRIPTION
Hello! I was looking for a *simple* Jive API gem and found yours. It looks like it hasn't been worked on for a while, but its still really useful I think. I pulled it and found that I needed to make some changes and fix a couple things to make it useful for me. I wanted to contribute these changes back in hopes you'll be interested and incorporate them. Here's a rundown of the changes:

- I don't use memcached so I abstracted that out and made the caching method optional via dependency injection. I looked at the code and created a simple interface for various cache methods, created one for memcache, and added a second one for PORO in memory hash. I made the memcache option the default option, so no change for end users who already have memcached set up
- I made a couple of little improvements and fixes as I found the need for them. I added a new Video content object. I also fixed the response error checking because the method in use doesn't seem to work with newer HTTParty versions. I also added Content#content_methods to make it easier for people coming into the lib from outside to find their way around
- I made the tests use the new Jive::Cache::Hashcache caching method so that tests run without the external dependency
- I expanded the README

I hope you find this to your liking and will incorporate it!